### PR TITLE
[BE] 로컬 회원가입/로그인 기능 및 테스트 코드 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,18 +29,13 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
-	// 시큐리티 잠깐 끄기 (반드시 주석 처리)
-	// implementation 'org.springframework.boot:spring-boot-starter-security'
-
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-
-	// 이미 주석 처리된 것들 (지금은 안 써도 됨)
-	// implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	// implementation 'org.springframework.boot:spring-boot-starter-quartz'
-	// implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-quartz'
+	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/runnershi/runnershi/auth/AuthController.java
+++ b/src/main/java/runnershi/runnershi/auth/AuthController.java
@@ -1,0 +1,32 @@
+package runnershi.runnershi.auth;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import runnershi.runnershi.domain.user.dto.AuthResponse;
+import runnershi.runnershi.domain.user.dto.LoginRequest;
+import runnershi.runnershi.domain.user.dto.SignupRequest;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<AuthResponse> signup(@RequestBody @Valid SignupRequest request) {
+        AuthResponse response = authService.signup(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthResponse> login(@RequestBody @Valid LoginRequest request) {
+        AuthResponse response = authService.login(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/runnershi/runnershi/auth/AuthService.java
+++ b/src/main/java/runnershi/runnershi/auth/AuthService.java
@@ -1,0 +1,70 @@
+package runnershi.runnershi.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import runnershi.runnershi.domain.user.User;
+import runnershi.runnershi.domain.user.UserRepository;
+import runnershi.runnershi.domain.user.dto.AuthResponse;
+import runnershi.runnershi.domain.user.dto.LoginRequest;
+import runnershi.runnershi.domain.user.dto.SignupRequest;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public AuthResponse signup(SignupRequest request) {
+        // 1) 이메일 중복 체크
+        if(userRepository.existsByEmail(request.email())) {
+            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+        }
+
+        // 2) 닉네임 중복 체크
+        if(userRepository.existsByNickname(request.nickname())) {
+            throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+        }
+
+        // 3) 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(request.password());
+
+        // 4) 유저 생성 & 저장
+        User user = User.createdLocalUser(
+                request.email(),
+                encodedPassword,
+                request.nickname(),
+                request.countryCode(),
+                request.regionCode()
+        );
+
+        // 5) 응답 DTO 반환
+        User saved = userRepository.save(user);
+
+        return new AuthResponse(saved.getId(), saved.getEmail(), saved.getNickname());
+    }
+
+
+    @Transactional(readOnly = true)
+    public AuthResponse login(LoginRequest request) {
+        // 1) 이메일로 유저 조회
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(() -> new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다."));
+
+        // 2) 비밀번호 검증
+        if(user.getPasswordHash() == null) {
+            // 소셜 전용 계정일 수도 있음
+            throw new IllegalArgumentException("로컬 로그인 비밀번호가 설정되지 않은 계정입니다.");
+        }
+
+        if(!passwordEncoder.matches(request.password(), user.getPasswordHash())) {
+            throw new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다.");
+        }
+
+        // 3) 로그인 성공 -> 나중에 여기서 JWT 발급 예정
+        return new AuthResponse(user.getId(), user.getEmail(), user.getNickname());
+    }
+}

--- a/src/main/java/runnershi/runnershi/domain/user/User.java
+++ b/src/main/java/runnershi/runnershi/domain/user/User.java
@@ -1,0 +1,73 @@
+package runnershi.runnershi.domain.user;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(
+        name = "users",
+        indexes = {
+                @Index(name = "idx_users_email", columnList = "email", unique = true),
+                @Index(name = "idx_users_nickname", columnList = "nickname", unique = true)
+        }
+
+)
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 255, unique = true)
+    private String email;
+
+    @Column(name = "password_hash", length = 255)
+    private String passwordHash;
+
+    @Column(nullable = false, length = 30, unique = true)
+    private String nickname;
+
+    @Column(length = 2)
+    private String countryCode;
+
+    @Column(length = 20)
+    private String regionCode;
+
+    @Column(nullable = false, length = 20)
+    private String status;
+
+    @Column(nullable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(nullable = false)
+    private OffsetDateTime updatedAt;
+
+    // ==== 정적 팩토리 메서드 ====
+
+    public static User createdLocalUser(String email,
+                                        String encodedPassword,
+                                        String nickname,
+                                        String countryCode,
+                                        String regionCode) {
+        OffsetDateTime now = OffsetDateTime.now();
+        return User.builder()
+                .email(email)
+                .passwordHash(encodedPassword)
+                .nickname(nickname)
+                .countryCode(countryCode)
+                .regionCode(regionCode)
+                .status("ACTIVE")
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+    }
+
+    // 추후 닉네임 변경, 상태 변경 등의 도메인 메서드를 여기에 추가
+}

--- a/src/main/java/runnershi/runnershi/domain/user/UserRepository.java
+++ b/src/main/java/runnershi/runnershi/domain/user/UserRepository.java
@@ -1,0 +1,13 @@
+package runnershi.runnershi.domain.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+
+    boolean existsByNickname(String nickname);
+}

--- a/src/main/java/runnershi/runnershi/domain/user/dto/AuthResponse.java
+++ b/src/main/java/runnershi/runnershi/domain/user/dto/AuthResponse.java
@@ -1,0 +1,8 @@
+package runnershi.runnershi.domain.user.dto;
+
+public record AuthResponse(
+        Long userId,
+        String email,
+        String nickname
+        // Todo: 나중에 accessToken, refreshToken 추가 예정
+) {}

--- a/src/main/java/runnershi/runnershi/domain/user/dto/LoginRequest.java
+++ b/src/main/java/runnershi/runnershi/domain/user/dto/LoginRequest.java
@@ -1,0 +1,13 @@
+package runnershi.runnershi.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @Email
+        @NotBlank
+        String email,
+
+        @NotBlank
+        String password
+) {}

--- a/src/main/java/runnershi/runnershi/domain/user/dto/SignupRequest.java
+++ b/src/main/java/runnershi/runnershi/domain/user/dto/SignupRequest.java
@@ -1,0 +1,22 @@
+package runnershi.runnershi.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SignupRequest(
+        @Email
+        @NotBlank
+        String email,
+
+        @NotBlank
+        @Size(min = 8, max = 50)
+        String password,
+
+        @NotBlank
+        @Size(min = 2, max = 30)
+        String nickname,
+
+        String countryCode,
+        String regionCode
+) {}

--- a/src/main/java/runnershi/runnershi/global/security/SecurityConfig.java
+++ b/src/main/java/runnershi/runnershi/global/security/SecurityConfig.java
@@ -1,0 +1,47 @@
+package runnershi.runnershi.global.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                // REST API 이므로 기본 제공 로그인 폼/CSRF 비활성화
+                .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
+
+                // 세션은 STATELESS로 (나중에 JWT로 확장하기 위함)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+
+                // URL별 권한 설정
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+
+                // 나중에 JWT 필터 추가할 자리
+                .logout(Customizer.withDefaults());
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        // BCrypt는 현재 가장 많이 쓰는 패스워드 해시 알고리즘 중 하나
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/test/java/runnershi/runnershi/auth/AuthControllerTest.java
+++ b/src/test/java/runnershi/runnershi/auth/AuthControllerTest.java
@@ -1,0 +1,140 @@
+package runnershi.runnershi.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import runnershi.runnershi.domain.user.dto.AuthResponse;
+import runnershi.runnershi.domain.user.dto.LoginRequest;
+import runnershi.runnershi.domain.user.dto.SignupRequest;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AuthControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    AuthService authService; // 더 이상 @MockBean이 아님! TestConfig에서 등록됨
+
+    /**
+     * Test 전용 Bean 등록
+     * Spring Boot 3.4 이상에서는 @MockBean 대신 이런 방식을 사용하라고 권장한다.
+     */
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        AuthService authService() {
+            return Mockito.mock(AuthService.class);
+        }
+    }
+
+    @Test
+    @DisplayName("회원가입 API - 정상 요청 시 200과 AuthResponse를 반환한다")
+    void signup_success() throws Exception {
+        // given
+        SignupRequest request = new SignupRequest(
+                "test@example.com",
+                "password123",
+                "runnerPeter",
+                "KR",
+                "KR-11"
+        );
+
+        AuthResponse response = new AuthResponse(
+                1L,
+                "test@example.com",
+                "runnerPeter"
+        );
+
+        given(authService.signup(Mockito.any(SignupRequest.class)))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(
+                        post("/api/auth/signup")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(1L))
+                .andExpect(jsonPath("$.email").value("test@example.com"))
+                .andExpect(jsonPath("$.nickname").value("runnerPeter"));
+    }
+
+    @Test
+    @DisplayName("로그인 성공")
+    void login_success() throws Exception {
+        LoginRequest request = new LoginRequest(
+                "login@example.com",
+                "password123"
+        );
+
+        AuthResponse response = new AuthResponse(
+                10L,
+                "login@example.com",
+                "runnerLogin"
+        );
+
+        given(authService.login(Mockito.any()))
+                .willReturn(response);
+
+        mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(10L))
+                .andExpect(jsonPath("$.email").value("login@example.com"))
+                .andExpect(jsonPath("$.nickname").value("runnerLogin"));
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 이미 사용 중인 이메일이면 IllegalArgumentException이 발생한다 (예외 핸들러 미구현 상태)")
+    void signup_fail() throws Exception {
+        // given
+        SignupRequest request = new SignupRequest(
+                "dup@example.com",
+                "password123",
+                "runnerPeter",
+                "KR",
+                "KR-11"
+        );
+
+        given(authService.signup(Mockito.any()))
+                .willThrow(new IllegalArgumentException("이미 사용 중인 이메일입니다."));
+
+        // when & then
+        assertThatThrownBy(() ->
+                mockMvc.perform(
+                                post("/api/auth/signup")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(objectMapper.writeValueAsString(request))
+                        )
+                        .andReturn()   // perform 결과까지 포함해서 하나의 람다로 감싸기
+        )
+                .isInstanceOf(ServletException.class) // 바깥으로 보이는 예외 타입
+                .hasRootCauseInstanceOf(IllegalArgumentException.class) // 실제 원인
+                .hasRootCauseMessage("이미 사용 중인 이메일입니다.");
+    }
+}

--- a/src/test/java/runnershi/runnershi/auth/AuthServiceTest.java
+++ b/src/test/java/runnershi/runnershi/auth/AuthServiceTest.java
@@ -1,0 +1,235 @@
+package runnershi.runnershi.auth;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import runnershi.runnershi.domain.user.User;
+import runnershi.runnershi.domain.user.UserRepository;
+import runnershi.runnershi.domain.user.dto.AuthResponse;
+import runnershi.runnershi.domain.user.dto.LoginRequest;
+import runnershi.runnershi.domain.user.dto.SignupRequest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    AuthService authService;
+
+    @Nested
+    @DisplayName("회원가입(signup)")
+    class SignupTests {
+
+        @Test
+        @DisplayName("정상 회원가입 - 이메일/닉네임 중복이 없으면 유저가 저장된다")
+        void signup_success() {
+            //given
+            SignupRequest request = new SignupRequest(
+                    "test@example.com",
+                    "password123",
+                    "runnerPeter",
+                    "KR",
+                    "KR-11"
+            );
+
+            given(userRepository.existsByEmail("test@example.com")).willReturn(false);
+            given(userRepository.existsByNickname("runnerPeter")).willReturn(false);
+            given(passwordEncoder.encode("password123")).willReturn("EncodedPassword");
+
+            ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+            given(userRepository.save(userCaptor.capture()))
+                    .willAnswer(invention -> {
+                        User u = userCaptor.getValue();
+                        return User.builder()
+                                .id(1L)
+                                .email(u.getEmail())
+                                .passwordHash(u.getPasswordHash())
+                                .nickname(u.getNickname())
+                                .countryCode(u.getCountryCode())
+                                .regionCode(u.getRegionCode())
+                                .status(u.getStatus())
+                                .createdAt(u.getCreatedAt())
+                                .updatedAt(u.getUpdatedAt())
+                                .build();
+                    });
+            // when
+            AuthResponse response = authService.signup(request);
+
+            // then
+            assertThat(response.userId()).isEqualTo(1L);
+            assertThat(response.email()).isEqualTo("test@example.com");
+            assertThat(response.nickname()).isEqualTo("runnerPeter");
+
+            User savedUser = userCaptor.getValue();
+            assertThat(savedUser.getEmail()).isEqualTo("test@example.com");
+            assertThat(savedUser.getPasswordHash()).isEqualTo("EncodedPassword");
+        }
+
+        @Test
+        @DisplayName("회원가입 실패 - 이메일이 이미 존재하면 예외 발생")
+        void signup_fail_email_exist() {
+            // given
+            SignupRequest request = new SignupRequest(
+                    "dup@example.com",
+                    "password123",
+                    "runnerPeter",
+                    "KR",
+                    "KR-11"
+            );
+
+            given(userRepository.existsByEmail("dup@example.com")).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> authService.signup(request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("이미 사용 중인 이메일");
+        }
+
+        @Test
+        @DisplayName("회원가입 실패 - 닉네임이 이미 존재하면 예외 발생")
+        void signup_fail_nickname_exist() {
+            SignupRequest request = new SignupRequest(
+                    "test@example.com",
+                    "password123",
+                    "dupNickname",
+                    "KR",
+                    "KR-11"
+            );
+
+            given(userRepository.existsByEmail("test@example.com")).willReturn(false);
+            given(userRepository.existsByNickname("dupNickname")).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> authService.signup(request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("이미 사용 중인 닉네임");
+        }
+    }
+
+    @Nested
+    @DisplayName("로그인(Login)")
+    class LoginTests {
+
+        @Test
+        @DisplayName("정상 로그인 - 이메일과 비밀번호가 일치하면 AuthResponse를 반환한다")
+        void login_success() {
+            // given
+            LoginRequest request = new LoginRequest(
+                    "login@example.com",
+                    "password123"
+            );
+
+            User user = User.builder()
+                    .id(10L)
+                    .email("login@example.com")
+                    .passwordHash("EncodedPassword")
+                    .nickname("runnerLogin")
+                    .status("ACTIVE")
+                    .build();
+
+            given(userRepository.findByEmail("login@example.com"))
+                    .willReturn(Optional.of(user));
+
+            given(passwordEncoder.matches("password123", "EncodedPassword"))
+                    .willReturn(true);
+
+            // when
+            AuthResponse response = authService.login(request);
+            ;
+
+            // then
+            assertThat(response.userId()).isEqualTo(10L);
+            assertThat(response.email()).isEqualTo("login@example.com");
+            assertThat(response.nickname()).isEqualTo("runnerLogin");
+        }
+
+        @Test
+        @DisplayName("로그인 실패 - 해당 이메일의 유저가 없으면 예외 발생")
+        void login_fail_user_not_found() {
+            // given
+            LoginRequest request = new LoginRequest(
+                    "notfound@example.com",
+                    "password123"
+            );
+
+            given(userRepository.findByEmail("notfound@example.com"))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> authService.login(request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("이메일 또는 비밀번호가 올바르지 않습니다");
+        }
+
+        @Test
+        @DisplayName("로그인 실패 - passwordHash가 null이면(소셜 전용 계정) 예외 발생")
+        void login_fail_no_password_set() {
+            // given
+            LoginRequest request = new LoginRequest(
+                    "social-only@example.com",
+                    "password123"
+            );
+
+            User socialOnlyUser = User.builder()
+                    .id(20L)
+                    .email("social-only@example.com")
+                    .passwordHash(null)
+                    .status("ACTIVE")
+                    .build();
+
+            given(userRepository.findByEmail("social-only@example.com"))
+                    .willReturn(Optional.of(socialOnlyUser));
+
+            // when & then
+            assertThatThrownBy(() -> authService.login(request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("로컬 로그인 비밀번호가 설정되지 않은 계정");
+        }
+
+        @Test
+        @DisplayName("로그인 실패 - 비밀번호가 일치하지 않으면 예외 발생")
+        void login_fail_wrong_password() {
+            // given
+            LoginRequest request = new LoginRequest(
+                    "login@example.com",
+                    "wrongPassword"
+            );
+
+            User user = User.builder()
+                    .id(10L)
+                    .email("login@example.com")
+                    .passwordHash("EncodedPassword")
+                    .nickname("runnerLogin")
+                    .status("ACTIVE")
+                    .build();
+
+            given(userRepository.findByEmail("login@example.com"))
+                    .willReturn(Optional.of(user));
+
+            given(passwordEncoder.matches("wrongPassword", "EncodedPassword"))
+                    .willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> authService.login(request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("이메일 또는 비밀번호가 올바르지 않습니다");
+        }
+    }
+}

--- a/src/test/java/runnershi/runnershi/domain/user/UserRepositoryTest.java
+++ b/src/test/java/runnershi/runnershi/domain/user/UserRepositoryTest.java
@@ -1,0 +1,20 @@
+package runnershi.runnershi.domain.user;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserRepositoryTest {
+
+    @Test
+    void findByEmail() {
+    }
+
+    @Test
+    void existsByEmail() {
+    }
+
+    @Test
+    void existsByNickname() {
+    }
+}


### PR DESCRIPTION
## 📝 PR 제목
<!-- 예: [BE] 러닝 기록 생성 API 추가 / [APP] 러닝 상세 화면 UI 구현 -->

---

## 1. 작업 종류 (Type)
<!-- 해당되는 항목에만 ✅ 표시 -->

- [x] feat      : 새로운 기능 추가
- [ ] fix       : 버그 수정
- [ ] refactor  : 코드 리팩토링(기능 변화 없음)
- [ ] chore     : 빌드/설정/환경 변경
- [ ] docs      : 문서 추가/수정
- [x] test      : 테스트 코드 추가/수정
- [ ] style     : 포맷팅/오타 등 논리 변경 없는 수정

---

## 2. 작업 내용 (What)
<!-- 무엇을 왜 했는지, 리뷰어가 한 번에 이해할 수 있게 3~5줄 정도로 -->

- 로컬 회원가입(signup) 기능 구현: 이메일/닉네임 중복 검사 및 패스워드 암호화 적용  
- 로컬 로그인(login) 기능 구현: 이메일 조회 및 패스워드 검증 로직 추가  
- AuthController API 구현 및 성공/실패 테스트 코드 작성  
- H2 기반의 로컬 환경에서 회원가입/로그인 로직 검증 완료 

### 관련 이슈
<!-- 예: Close #12 / Resolve RunnersHi-kr/runnershi-backend#34 -->
- 없음

---

## 3. 변경 상세 (Details)

### 3-1. 기능 변경 / 추가 내용
<!-- 주요 로직, 플로우 변경사항. API 응답/요청이 바뀌면 꼭 여기에 명시 -->

- AuthService.signup() 로직 추가
- AuthService.login() 로직 추가
- 이메일, 닉네임 중복 여부 검사 적용
- 소셜 전용 계정(passwordHash null) 예외 처리
- AuthController /api/auth/signup, /api/auth/login 구현

### 3-2. API / 인터페이스 변경 (있다면만 작성)
<!-- 엔드포인트, 파라미터, 응답 스펙 변경 등 -->

#### `POST /api/auth/signup`

- 요청:
```json
{
  "email": "string",
  "password": "string",
  "nickname": "string",
  "countryCode": "string",
  "regionCode": "string"
}
```

- 응답:
```json
{
  "userId": 1,
  "email": "string",
  "nickname": "string"
}
```

#### `POST /api/auth/login`

- 요청:
```json
{
  "email": "string",
  "password": "string"
}
```

- 응답:
```json
{
  "userId": 10,
  "email": "string",
  "nickname": "string"
}
```

### 3-3. DB / 스키마 변경 (있다면만 작성)
<!-- 마이그레이션, 컬럼 추가/삭제, 인덱스 변경 등 -->

- 변경 내용: 없음 (기존 'users' 엔티티 기반 JPA 자동 생성 유지)
- 마이그레이션 방법: 해당 없음

---

## 4. 테스트 결과 (Test)
<!-- 로컬/CI에서 어떤 테스트를 돌렸는지, 실제로 실행한 명령을 적으면 좋음 -->

- [x] 로컬 빌드 / 테스트 통과
    - 명령어: `./gradlew test`
- [x] 주요 기능 수동 테스트 완료
    - 시나리오 1: 정상 회원가입 요청 → 200 응답 및 AuthResponse 반환
    - 시나리오 2: 중복 이메일로 회원가입 요청 → 예외 발생 및 실패 응답 확인
    - 시나리오 3: 정상 로그인 요청 → 200 응답 및 AuthResponse 반환
    - 시나리오 4: 잘못된 비밀번호로 로그인 요청 → 예외 발생 및 실패 응답 확인

---

## 5. 영향 범위 (Impact)
<!-- 어디에 영향이 가는지, 브레이킹 체인지 여부를 리뷰어가 한눈에 보게 -->

- [x] Breaking Change 없음
- [ ] Breaking Change 있음 (아래에 상세 설명)

### 잠재적 영향
- 성능 영향: 현재는 단순 인증 로직으로 성능 영향 거의 없음. 다만 향후 사용자 수 증가 시 이메일/닉네임 중복 조회 쿼리가 빈번하게 발생할 가능성 있음.
- 보안/인증 관련 영향: 로컬 로그인/회원가입 API가 추가됨에 따라 인증 엔드포인트가 외부에 노출됨. 추후 JWT 적용 시 필터 및 보안 설정 확장 필요.
- 기타 영향: 클라이언트(앱/웹) 측에서 신규 엔드포인트(`/api/auth/signup`, `/api/auth/login`)와 연동이 필요함. 이후 소셜 로그인 추가 시 API 구조 확장 가능성 존재.

---

## 6. 리뷰어에게 요청사항 (Review Points)
<!-- 특히 봐줬으면 하는 부분, 고민되는 설계 포인트, 트레이드오프 등을 적기 -->

- AuthService 예외 처리 방식(IllegalArgumentException 사용)이 팀 컨벤션에 맞는지 확인 부탁.
- 추후 글로벌 예외 처리(@ControllerAdvice) 적용 시, 현재 예외 구조가 무리가 없는지 검토 부탁.
- API 스펙이 향후 OAuth2.0 기반 소셜 로그인 추가 시에도 확장 가능한 구조인지 피드백 부탁
